### PR TITLE
Changed max php Version in composer to 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     }
   ],
   "require": {
-    "php": "~7.0.0",
+    "php": "~7.1.0",
     "magento/product-community-edition": "^2.1.8"
   },
   "require-dev": {


### PR DESCRIPTION
You already created the version 1.0.2 with the compatibily for php 7.1. Unfortunately the composer File only allows php versions < 7.1.